### PR TITLE
r14: Add wifi_2g and wifi_5g leds to device tree

### DIFF
--- a/feeds/mediatek-sdk/mediatek-sdk/files-5.4/arch/arm64/boot/dts/mediatek/mt7986a-motorola-r14.dts
+++ b/feeds/mediatek-sdk/mediatek-sdk/files-5.4/arch/arm64/boot/dts/mediatek/mt7986a-motorola-r14.dts
@@ -41,6 +41,18 @@
 	leds {
 		compatible = "gpio-leds";
 
+		wifi_2g {
+			label = "wifi_2g";
+			gpios = <&pio 1 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		wifi_5g {
+			label = "wifi_5g";
+			gpios = <&pio 2 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
 		power {
 			label = "power";
 			gpios = <&pio 11 GPIO_ACTIVE_HIGH>;


### PR DESCRIPTION
Use these pins as gpios and register them with the gpio led class driver

SW-2394