### PR TITLE
r14: Add samba-manager

### DIFF
--- a/profiles/motorola_r14.yml
+++ b/profiles/motorola_r14.yml
@@ -14,20 +14,8 @@ include:
   - minim
 packages:
   - uboot-envtools
-  - kmod-usb-storage
-  - kmod-usb-storage-uas
-  - kmod-fuse
-  - kmod-fs-f2fs
-  - kmod-fs-exfat
-  - kmod-fs-vfat
-  - kmod-fs-ext4
-  - kmod-fs-ntfs
-  - kmod-fs-hfs
-  - kmod-fs-hfsplus
   - kmod-usb-ledtrig-usbport
-  - block-mount
-  - samba4-server
-  - fdisk
+  - samba-manager
 diffconfig: |
   CONFIG_VERSION_PRODUCT="minim_r14"
   CONFIG_VERSION_HWREV=""


### PR DESCRIPTION
This package depends on all of the kmod-fs-*, blockd, and samba4 packages we need, so remove them from the list

SW-2507
SW-2549