### PR TITLE
motorola_r14: Reverse lan LED labels

### DIFF
--- a/feeds/mediatek-sdk/mediatek-sdk/files-5.4/arch/arm64/boot/dts/mediatek/mt7986a-motorola-r14.dts
+++ b/feeds/mediatek-sdk/mediatek-sdk/files-5.4/arch/arm64/boot/dts/mediatek/mt7986a-motorola-r14.dts
@@ -77,26 +77,26 @@
 			default-state = "off";
 		};
 
-		lan4 {
-			label = "lan4";
+		lan1 {
+			label = "lan1";
 			gpios = <&switch 9 GPIO_ACTIVE_LOW>;
-			default-state = "off";
-		};
-
-		lan3 {
-			label = "lan3";
-			gpios = <&switch 7 GPIO_ACTIVE_LOW>;
 			default-state = "off";
 		};
 
 		lan2 {
 			label = "lan2";
+			gpios = <&switch 7 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		lan3 {
+			label = "lan3";
 			gpios = <&switch 5 GPIO_ACTIVE_LOW>;
 			default-state = "off";
 		};
 
-		lan1 {
-			label = "lan1";
+		lan4 {
+			label = "lan4";
 			gpios = <&switch 3 GPIO_ACTIVE_LOW>;
 			default-state = "off";
 		};

--- a/patches/ipq807x/0002-ipq807x-buildsystem-patches-required-by-the-target.patch
+++ b/patches/ipq807x/0002-ipq807x-buildsystem-patches-required-by-the-target.patch
@@ -8,8 +8,8 @@ properly.
 
 Signed-off-by: John Crispin <john@phrozen.org>
 ---
- target/linux/generic/config-4.4 | 4794 +++++++++++++++++++++++++++++++
- 1 file changed, 4794 insertions(+)
+ target/linux/generic/config-4.4 | 4795 +++++++++++++++++++++++++++++++
+ 1 file changed, 4795 insertions(+)
  create mode 100644 target/linux/generic/config-4.4
 
 diff --git a/target/linux/generic/config-4.4 b/target/linux/generic/config-4.4
@@ -17,7 +17,7 @@ new file mode 100644
 index 0000000000..4e7602f236
 --- /dev/null
 +++ b/target/linux/generic/config-4.4
-@@ -0,0 +1,4794 @@
+@@ -0,0 +1,4795 @@
 +CONFIG_32BIT=y
 +# CONFIG_6LOWPAN is not set
 +# CONFIG_6PACK is not set
@@ -1663,6 +1663,7 @@ index 0000000000..4e7602f236
 +# CONFIG_IP6_NF_NAT is not set
 +# CONFIG_IP6_NF_RAW is not set
 +# CONFIG_IP6_NF_TARGET_HL is not set
++# CONFIG_IP6_NF_TARGET_MASQUERADE is not set
 +# CONFIG_IP6_NF_TARGET_REJECT is not set
 +# CONFIG_IP6_NF_TARGET_SYNPROXY is not set
 +# CONFIG_IPACK_BUS is not set

--- a/patches/ipq807x/0003-linux-modules-fix-some-v4.4-dependencies.patch
+++ b/patches/ipq807x/0003-linux-modules-fix-some-v4.4-dependencies.patch
@@ -19,7 +19,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
  package/kernel/linux/modules/fs.mk         |  3 +-
  package/kernel/linux/modules/iio.mk        |  4 +--
  package/kernel/linux/modules/netdevices.mk |  2 +-
- package/kernel/linux/modules/netfilter.mk  | 15 ++++-----
+ package/kernel/linux/modules/netfilter.mk  | 16 ++++-----
  package/kernel/linux/modules/netsupport.mk |  6 ++--
  package/kernel/linux/modules/other.mk      | 36 ++++++++++++++++++++--
  package/kernel/linux/modules/usb.mk        | 21 ++++++++++++-
@@ -27,7 +27,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
  toolchain/gcc/Config.in                    |  5 +++
  toolchain/gcc/Config.version               |  1 +
  toolchain/kernel-headers/Makefile          |  2 +-
- 20 files changed, 143 insertions(+), 40 deletions(-)
+ 20 files changed, 144 insertions(+), 40 deletions(-)
 
 diff --git a/config/Config-images.in b/config/Config-images.in
 index b869ccae70..de11c52676 100644
@@ -116,7 +116,7 @@ index 60f031e9a7..cee40ee008 100644
  $(eval $(if $(NF_KMOD),$(call nf_add,NF_CONNTRACK6,CONFIG_NF_CONNTRACK_IPV6, $(P_V6)nf_conntrack_ipv6),))
  
  $(eval $(if $(NF_KMOD),$(call nf_add,IPT_IPV6,CONFIG_IP6_NF_FILTER, $(P_V6)ip6table_filter),))
-@@ -181,11 +183,15 @@ $(eval $(call nf_add,IPT_IPV6_EXTRA,CONFIG_IP6_NF_MATCH_RT, $(P_V6)ip6t_rt))
+@@ -181,11 +183,16 @@ $(eval $(call nf_add,IPT_IPV6_EXTRA,CONFIG_IP6_NF_MATCH_RT, $(P_V6)ip6t_rt))
  
  # kernel only
  $(eval $(if $(NF_KMOD),$(call nf_add,NF_NAT,CONFIG_NF_NAT, $(P_XT)nf_nat),))
@@ -128,6 +128,7 @@ index 60f031e9a7..cee40ee008 100644
  $(eval $(if $(NF_KMOD),$(call nf_add,IPT_NAT,CONFIG_IP_NF_NAT, $(P_V4)iptable_nat),))
  $(eval $(if $(NF_KMOD),$(call nf_add,IPT_NAT6,CONFIG_IP6_NF_NAT, $(P_V6)ip6table_nat),))
  $(eval $(if $(NF_KMOD),$(call nf_add,IPT_NAT6,CONFIG_IP6_NF_TARGET_NPT, $(P_V6)ip6t_NPT),))
++$(eval $(if $(NF_KMOD),$(call nf_add,NF_NAT6,CONFIG_NF_NAT_IPV6, $(P_V6)nf_nat_ipv6, lt 4.18),))
 +$(eval $(if $(NF_KMOD),$(call nf_add,NF_NAT6,CONFIG_NF_NAT_MASQUERADE_IPV6, $(P_V6)nf_nat_masquerade_ipv6, lt 4.18),))
  
  # userland only


### PR DESCRIPTION
The ports are labeled in the reverse order of what we expected, so flip them around.

SW-2886