### PR TITLE
patches: minim: Improve dropbear.init patch a bit

### DIFF
--- a/patches/minim/0004-enable-ssh-via-web-admin.patch
+++ b/patches/minim/0004-enable-ssh-via-web-admin.patch
@@ -1,43 +1,33 @@
-From bfe68cfe84e3132ef32122d8cf0cba9f15491ee5 Mon Sep 17 00:00:00 2001
+From 6508729b1be71b305e1a2ac8f529c05724aff699 Mon Sep 17 00:00:00 2001
 From: Sagar Jain <sagarj@minim.com>
 Date: Tue, 6 Dec 2022 11:21:28 +0530
-Subject: [PATCH 1/1] r14: enable ssh via web-admin.
+Subject: [PATCH] r14: enable ssh via web-admin.
 
 SW-2703
 ---
- .../services/dropbear/files/dropbear.init     | 30 +++++++++++++++----
- 1 file changed, 24 insertions(+), 6 deletions(-)
+ .../services/dropbear/files/dropbear.init     | 21 +++++++++++++++++++
+ 1 file changed, 21 insertions(+)
 
 diff --git a/package/network/services/dropbear/files/dropbear.init b/package/network/services/dropbear/files/dropbear.init
-index ea4cad2a8d..4480591559 100755
+index ea4cad2a8d..7ddb4af549 100755
 --- a/package/network/services/dropbear/files/dropbear.init
 +++ b/package/network/services/dropbear/files/dropbear.init
-@@ -9,8 +9,8 @@ USE_PROCD=1
- PROG=/usr/sbin/dropbear
- NAME=dropbear
+@@ -11,6 +11,8 @@ NAME=dropbear
  PIDCOUNT=0
--
--extra_command "killclients" "Kill ${NAME} processes except servers and yourself"
-+EXTRA_COMMANDS="killclients restart_admin restart_admin_enable"
-+EXTRA_HELP="	killclients Kill ${NAME} processes except servers and yourself"
+ 
+ extra_command "killclients" "Kill ${NAME} processes except servers and yourself"
++extra_command "restart_admin" "Temporarily start sshd"
++extra_command "restart_admin_enable" "Enable sshd permanently"
  
  _dropbearkey()
  {
-@@ -66,7 +66,7 @@ hk_generate_as_needed()
- 	kdir='/etc/dropbear'
- 
- 	kgen=''
--	for ktype in ed25519 ecdsa rsa; do
-+	for ktype in ecdsa rsa; do
- 		hk_verify "${kdir}/dropbear_${ktype}_host_key" && continue
- 
- 		kgen="${kgen} ${ktype}"
-@@ -102,6 +102,13 @@ append_ports()
+@@ -102,6 +104,14 @@ append_ports()
  	local ipaddrs="$1"
  	local port="$2"
  
 +	p=`fw_printenv -n mfg_provisioned 2> /dev/null`
-+	if [ "$p" == "1" -a ! -f /tmp/sshd_enable -a ! -f /proc/environment/sshd_enable ] ; then
++	s=`fw_printenv -n sshd_enable 2> /dev/null`
++	if [ "$p" == "1" -a ! -f /tmp/sshd_enable -a "$s" != "1" ] ; then
 +		# It is already provisioned.
 +		# Listen on loopback interface only
 +		ipaddrs="127.0.0.1"
@@ -46,7 +36,7 @@ index ea4cad2a8d..4480591559 100755
  	[ -z "$ipaddrs" ] && {
  		procd_append_param command -p "$port"
  		return
-@@ -227,6 +234,17 @@ shutdown() {
+@@ -227,6 +237,17 @@ shutdown() {
  	killall dropbear
  }
  
@@ -64,32 +54,6 @@ index ea4cad2a8d..4480591559 100755
  killclients()
  {
  	local ignore=''
-@@ -238,7 +256,7 @@ killclients()
- 	while [ "${pid}" -ne 0 ]
- 	 do
- 		# get parent process id
--		pid=$(cut -d ' ' -f 4 "/proc/${pid}/stat")
-+		pid=`cut -d ' ' -f 4 "/proc/${pid}/stat"`
- 		[ "${pid}" -eq 0 ] && break
- 
- 		# check if client connection
-@@ -249,14 +267,14 @@ killclients()
- 	done
- 
- 	# get all server pids that should be ignored
--	for server in $(cat /var/run/${NAME}.*.pid)
-+	for server in `cat /var/run/${NAME}.*.pid`
- 	 do
- 		append ignore "${server}"
- 	done
- 
- 	# get all running pids and kill client connections
- 	local skip
--	for pid in $(pidof "${NAME}")
-+	for pid in `pidof "${NAME}"`
- 	 do
- 		# check if correct program, otherwise process next pid
- 		grep -F -q -e "${PROG}" "/proc/${pid}/cmdline" || {
 -- 
-2.25.1
+2.30.2
 


### PR DESCRIPTION
* Use fw_printenv to get sshd_enable u-boot var
* Use the new openwrt extra_command convention
* Don't clobber changes that have been made in newer openwrt versions (vs the version used in zoom-7600, where this patch originated)

SW-2703