### PR TITLE
r14:changed power led pin from gpio6 to gpio10   SW-2987

### DIFF
--- a/feeds/mediatek-sdk/mediatek-sdk/files-5.4/arch/arm64/boot/dts/mediatek/mt7986a-motorola-r14.dts
+++ b/feeds/mediatek-sdk/mediatek-sdk/files-5.4/arch/arm64/boot/dts/mediatek/mt7986a-motorola-r14.dts
@@ -55,7 +55,7 @@
 
 		power {
 			label = "power";
-			gpios = <&pio 11 GPIO_ACTIVE_HIGH>;
+			gpios = <&pio 15 GPIO_ACTIVE_HIGH>;
 			default-state = "on";
 		};
 


### PR DESCRIPTION
modified motorola_r14.dtsi file to change the power led pin from gpio6 to gpio 10