### PR TITLE
patches: minim: Don't need to set ra_flags in dhcp config

### DIFF
--- a/patches/minim/0008-added-support-for-DHCPv6.patch
+++ b/patches/minim/0008-added-support-for-DHCPv6.patch
@@ -1,26 +1,25 @@
-From 46ad110faa2fc068cdddb499e61ce8488385b93e Mon Sep 17 00:00:00 2001
+From eb3239476f1e089146abdceac0b4f72ec8c484e1 Mon Sep 17 00:00:00 2001
 From: Sagar Jain <sagarj@minim.com>
 Date: Thu, 27 Oct 2022 12:11:45 +0530
-Subject: [PATCH 1/1] Added support for DHCPv6
+Subject: [PATCH] Added support for DHCPv6
 
 ---
- package/network/services/dnsmasq/files/dhcp.conf | 3 +++
- 1 file changed, 3 insertions(+)
+ package/network/services/dnsmasq/files/dhcp.conf | 2 ++
+ 1 file changed, 2 insertions(+)
 
 diff --git a/package/network/services/dnsmasq/files/dhcp.conf b/package/network/services/dnsmasq/files/dhcp.conf
-index 8c42ef782e..e609e04859 100644
+index 8c42ef782e..b08abdd030 100644
 --- a/package/network/services/dnsmasq/files/dhcp.conf
 +++ b/package/network/services/dnsmasq/files/dhcp.conf
-@@ -27,6 +27,9 @@ config dhcp lan
+@@ -27,6 +27,8 @@ config dhcp lan
  	option start 	100
  	option limit	150
  	option leasetime	12h
 +	option dhcpv6 server
 +	option ra server
-+	option ra_flags 'managed-config other-config'
  
  config dhcp wan
  	option interface	wan
 -- 
-2.25.1
+2.30.2
 

--- a/patches/minim/0009-dhcp-lease-time-and-IP-address-range-correction.patch
+++ b/patches/minim/0009-dhcp-lease-time-and-IP-address-range-correction.patch
@@ -25,7 +25,7 @@ index e609e04859..d650682347 100644
 +	option leasetime	24h
  	option dhcpv6 server
  	option ra server
- 	option ra_flags 'managed-config other-config'
+ 
 -- 
 2.25.1
 


### PR DESCRIPTION
Starting with openwrt 21.02 these ra_flags are set by default, and it turns out that the odhcpd daemon can't handle them being set twice, causing it to run with no ra flags in that case.

SW-3103