### PR TITLE
minim: patches: Handle radar detection with mesh+ap

### DIFF
--- a/patches/minim/0063-hostapd-Handle-radar-detection-with-mesh-ap.patch
+++ b/patches/minim/0063-hostapd-Handle-radar-detection-with-mesh-ap.patch
@@ -1,0 +1,111 @@
+From 5899f7c48d3449e7b844e88e62af4ac535fcbd4d Mon Sep 17 00:00:00 2001
+From: Brett Mastbergen <brettm@minim.com>
+Date: Tue, 30 May 2023 10:41:33 -0400
+Subject: [PATCH] hostapd: Handle radar detection with mesh+ap
+
+These two patches allow handling radar detection channel changes
+when operating simultaneous mesh and ap interfaces
+
+SW-3995
+---
+ ...hostapd_setup_wpa-in-hostapd_setup_b.patch | 48 +++++++++++++++++++
+ .../998-dfs-Handle-EBUSY-from-start-cac.patch | 32 +++++++++++++
+ 2 files changed, 80 insertions(+)
+ create mode 100644 package/network/services/hostapd/patches/997-mesh-Don-t-call-hostapd_setup_wpa-in-hostapd_setup_b.patch
+ create mode 100644 package/network/services/hostapd/patches/998-dfs-Handle-EBUSY-from-start-cac.patch
+
+diff --git a/package/network/services/hostapd/patches/997-mesh-Don-t-call-hostapd_setup_wpa-in-hostapd_setup_b.patch b/package/network/services/hostapd/patches/997-mesh-Don-t-call-hostapd_setup_wpa-in-hostapd_setup_b.patch
+new file mode 100644
+index 0000000000..c0970fb3b4
+--- /dev/null
++++ b/package/network/services/hostapd/patches/997-mesh-Don-t-call-hostapd_setup_wpa-in-hostapd_setup_b.patch
+@@ -0,0 +1,48 @@
++From 1118d19abea6c01ff869a150a545bbaba19658c0 Mon Sep 17 00:00:00 2001
++From: Brett Mastbergen <brettm@minim.com>
++Date: Tue, 30 May 2023 10:29:46 -0400
++Subject: [PATCH 2/2] mesh: Don't call hostapd_setup_wpa in hostapd_setup_bss
++
++Mesh interface configuration is deferred until join time, so
++don't call hostapd_setup_wpa here for mesh.  This same deferral
++is done in hostapd_setup_interface_complete_sync.
++
++SW-3995
++---
++ src/ap/hostapd.c | 13 ++++++++++++-
++ 1 file changed, 12 insertions(+), 1 deletion(-)
++
++diff --git a/src/ap/hostapd.c b/src/ap/hostapd.c
++index 4b88641a2..e76a9a360 100644
++--- a/src/ap/hostapd.c
+++++ b/src/ap/hostapd.c
++@@ -1115,6 +1115,7 @@ static int hostapd_setup_bss(struct hostapd_data *hapd, int first)
++ 	char force_ifname[IFNAMSIZ];
++ 	u8 if_addr[ETH_ALEN];
++ 	int flush_old_stations = 1;
+++	int delay_apply_cfg = 0;
++ 
++ 	wpa_printf(MSG_DEBUG, "%s(hapd=%p (%s), first=%d)",
++ 		   __func__, hapd, conf->iface, first);
++@@ -1327,7 +1328,17 @@ static int hostapd_setup_bss(struct hostapd_data *hapd, int first)
++ 		return -1;
++ 	}
++ 
++-	if ((conf->wpa || conf->osen) && hostapd_setup_wpa(hapd))
+++#ifdef CONFIG_MESH
+++	if (hapd->iface->mconf != NULL) {
+++		wpa_printf(MSG_DEBUG,
+++			   "%s: Mesh configuration will be applied while joining the mesh network",
+++			   hapd->iface->bss[0]->conf->iface);
+++		delay_apply_cfg = 1;
+++		wpa_printf(MSG_INFO, "DEBUGBRE: %s: don't call hostapd_setup_wpa", __func__);
+++	}
+++#endif /* CONFIG_MESH */
+++
+++	if (!delay_apply_cfg && (conf->wpa || conf->osen) && hostapd_setup_wpa(hapd))
++ 		return -1;
++ 
++ 	if (accounting_init(hapd)) {
++-- 
++2.30.2
++
+diff --git a/package/network/services/hostapd/patches/998-dfs-Handle-EBUSY-from-start-cac.patch b/package/network/services/hostapd/patches/998-dfs-Handle-EBUSY-from-start-cac.patch
+new file mode 100644
+index 0000000000..c44719dc65
+--- /dev/null
++++ b/package/network/services/hostapd/patches/998-dfs-Handle-EBUSY-from-start-cac.patch
+@@ -0,0 +1,32 @@
++From 1e6cd61d0fad6e1357caf4f021559f0f13176eb0 Mon Sep 17 00:00:00 2001
++From: Brett Mastbergen <brettm@minim.com>
++Date: Tue, 30 May 2023 10:28:32 -0400
++Subject: [PATCH 1/2] dfs: Handle -EBUSY from start cac
++
++If an interface requests a channel change, but gets -EBUSY, then
++a channel change is already in progress, so just return
++
++SW-3995
++---
++ src/ap/dfs.c | 5 +++++
++ 1 file changed, 5 insertions(+)
++
++diff --git a/src/ap/dfs.c b/src/ap/dfs.c
++index 5c99ecfd0..5d646e7c3 100644
++--- a/src/ap/dfs.c
+++++ b/src/ap/dfs.c
++@@ -1144,6 +1144,11 @@ static int hostapd_dfs_start_channel_switch(struct hostapd_iface *iface)
++ 	}
++ 
++ 	if (err) {
+++		if (err == -EBUSY) {
+++			wpa_printf(MSG_WARNING, "DFS: assuming CSA already scheduled");
+++			return 0;
+++		}
+++
++ 		wpa_printf(MSG_WARNING, "DFS failed to schedule CSA (%d) - trying fallback",
++ 			   err);
++ 		iface->freq = channel->freq;
++-- 
++2.30.2
++
+-- 
+2.30.2
+


### PR DESCRIPTION
These two patches allow handling radar detection channel changes when operating simultaneous mesh and ap interfaces

SW-3995